### PR TITLE
Fix/edge to edge display

### DIFF
--- a/app/src/main/java/dev/vivvvek/bubblepager/MainActivity.kt
+++ b/app/src/main/java/dev/vivvvek/bubblepager/MainActivity.kt
@@ -34,6 +34,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
@@ -51,6 +52,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.core.view.WindowCompat
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.PagerState
 import com.google.accompanist.pager.rememberPagerState
@@ -61,13 +63,14 @@ import dev.vivvvek.bubblepager.ui.theme.BubblePagerTheme
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         setContent {
             BubblePagerTheme {
                 val pagerState = rememberPagerState()
 
                 val systemUiController = rememberSystemUiController()
                 systemUiController.setSystemBarsColor(
-                    color = pages[pagerState.currentPage].color,
+                    color = Color.Transparent,
                     darkIcons = pagerState.currentPage == 2
                 )
 
@@ -114,7 +117,9 @@ fun BubblePagerContent(pagerState: PagerState) {
         }
         PagerTopAppBar(
             page = pagerState.currentPage,
-            modifier = Modifier.wrapContentSize()
+            modifier = Modifier
+                .wrapContentSize()
+                .statusBarsPadding()
         )
     }
 }

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,6 +2,6 @@
 <resources>
 
     <style name="Theme.BubblePager" parent="android:Theme.Material.Light.NoActionBar">
-        <item name="android:statusBarColor">@color/purple_700</item>
+        <item name="android:statusBarColor">#00FFFFFF</item>
     </style>
 </resources>


### PR DESCRIPTION
Fixed the system bar transparency to support edge to edge display. Now the circle goes from all the way up to behind the status bar and behind the navigation bar.

**### Result**
<img src="https://user-images.githubusercontent.com/67380664/174593421-4033f07b-1752-489b-9aaf-47c5af51d3aa.jpg" width="250">

